### PR TITLE
feat(frontend): Picocrank 1.15 calendar range selection and drag-to-move

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,7 +12,7 @@
         "@connectrpc/connect-web": "^2.1.1",
         "@tailwindcss/postcss": "^4.2.4",
         "@vitejs/plugin-basic-ssl": "^2.3.0",
-        "picocrank": "^1.14.1",
+        "picocrank": "^1.15.0",
         "pinia": "^3.0.4",
         "vite-plugin-mkcert": "^2.0.0",
         "vue": "^3.5.33",
@@ -168,6 +168,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -184,6 +185,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -200,6 +202,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -216,6 +219,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -232,6 +236,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -248,6 +253,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -264,6 +270,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -280,6 +287,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -296,6 +304,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -312,6 +321,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -328,6 +338,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -344,6 +355,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -360,6 +372,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -376,6 +389,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -392,6 +406,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -408,6 +423,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -424,6 +440,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -440,6 +457,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -456,6 +474,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -472,6 +491,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -488,6 +508,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -504,6 +525,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -520,6 +542,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -536,6 +559,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -552,6 +576,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -568,6 +593,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -907,331 +933,6 @@
       "integrity": "sha512-3ngTAv6F/Py35BsYbeeLeecvhMKdsKm4AoOETVhAA+Qc8nrA2I0kF7oa93mE9qnIurngOSpMnQ0x2nQY2FPviA==",
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
-      "cpu": [
-        "arm"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
-      "cpu": [
-        "loong64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
-      "cpu": [
-        "ppc64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
-      "cpu": [
-        "s390x"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
-    },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
     "node_modules/@tailwindcss/node": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
@@ -1497,12 +1198,6 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
-    },
-    "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-      "license": "MIT"
     },
     "node_modules/@vitejs/plugin-basic-ssl": {
       "version": "2.3.0",
@@ -1920,6 +1615,8 @@
       "integrity": "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "optional": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2452,93 +2149,19 @@
       "license": "ISC"
     },
     "node_modules/picocrank": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/picocrank/-/picocrank-1.14.1.tgz",
-      "integrity": "sha512-N/aGK/deicXevv+n3zWaKrUe66d4QYQ/7SPinEr4fprljNpXQHSl2EBDlmTNlLoujR3QJHClfRO8Gusj2Hs5MQ==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/picocrank/-/picocrank-1.15.0.tgz",
+      "integrity": "sha512-nKqKYTcM7ypVgiILtiBluueLrP3yJ8bcCnGUPxovbNJsZz8Y3V+poqQbKGrx9mMTHzj1qHgHxzJXqy4jwpojzA==",
       "license": "ISC",
       "dependencies": {
-        "@hugeicons/core-free-icons": "^4.0.0",
+        "@hugeicons/core-free-icons": "^4.1.1",
         "@hugeicons/vue": "^1.0.5",
-        "@vitejs/plugin-vue": "^6.0.4",
+        "@vitejs/plugin-vue": "^6.0.6",
         "femtocrank": "^2.5.0",
-        "unplugin-vue-components": "^31.0.0",
-        "vite": "^7.3.1",
-        "vue": "^3.5.30",
-        "vue-router": "^5.0.3"
-      }
-    },
-    "node_modules/picocrank/node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
-      "license": "MIT",
-      "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
-      },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      },
-      "funding": {
-        "url": "https://github.com/vitejs/vite?sponsor=1"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.3"
-      },
-      "peerDependencies": {
-        "@types/node": "^20.19.0 || >=22.12.0",
-        "jiti": ">=1.21.0",
-        "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
-        "sass": "^1.70.0",
-        "sass-embedded": "^1.70.0",
-        "stylus": ">=0.54.8",
-        "sugarss": "^5.0.0",
-        "terser": "^5.16.0",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "@types/node": {
-          "optional": true
-        },
-        "jiti": {
-          "optional": true
-        },
-        "less": {
-          "optional": true
-        },
-        "lightningcss": {
-          "optional": true
-        },
-        "sass": {
-          "optional": true
-        },
-        "sass-embedded": {
-          "optional": true
-        },
-        "stylus": {
-          "optional": true
-        },
-        "sugarss": {
-          "optional": true
-        },
-        "terser": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
+        "unplugin-vue-components": "^32.0.0",
+        "vite": "^8.0.10",
+        "vue": "^3.5.33",
+        "vue-router": "^5.0.6"
       }
     },
     "node_modules/picomatch": {
@@ -2696,50 +2319,6 @@
       "integrity": "sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==",
       "license": "MIT"
     },
-    "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/estree": "1.0.8"
-      },
-      "bin": {
-        "rollup": "dist/bin/rollup"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      },
-      "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
-        "fsevents": "~2.3.2"
-      }
-    },
     "node_modules/scule": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/scule/-/scule-1.3.0.tgz",
@@ -2860,18 +2439,17 @@
       }
     },
     "node_modules/unplugin": {
-      "version": "2.3.11",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-2.3.11.tgz",
-      "integrity": "sha512-5uKD0nqiYVzlmCRs01Fhs2BdkEgBS3SAVP6ndrBsuK42iC2+JHyxM05Rm9G8+5mkmRtzMZGY8Ct5+mliZxU/Ww==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "acorn": "^8.15.0",
         "picomatch": "^4.0.3",
         "webpack-virtual-modules": "^0.6.2"
       },
       "engines": {
-        "node": ">=18.12.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/unplugin-utils": {
@@ -2891,9 +2469,9 @@
       }
     },
     "node_modules/unplugin-vue-components": {
-      "version": "31.1.0",
-      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-31.1.0.tgz",
-      "integrity": "sha512-9EbV5ark21A4BOBt6RJGJXCVD2I1eoxTZL1TAvNgYTokcrFIiuxpufb8owyWn7n+z2x8daz/ltZq6IRRKL3ydQ==",
+      "version": "32.0.0",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-32.0.0.tgz",
+      "integrity": "sha512-uLdccgS7mf3pv1bCCP20y/hm+u1eOjAmygVkh+Oa70MPkzgl1eQv1L0CwdHNM3gscO8/GDMGIET98Ja47CBbZg==",
       "license": "MIT",
       "dependencies": {
         "chokidar": "^5.0.0",
@@ -2903,7 +2481,7 @@
         "obug": "^2.1.1",
         "picomatch": "^4.0.3",
         "tinyglobby": "^0.2.15",
-        "unplugin": "^2.3.11",
+        "unplugin": "^3.0.0",
         "unplugin-utils": "^0.3.1"
       },
       "engines": {
@@ -3087,20 +2665,6 @@
         "pinia": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vue-router/node_modules/unplugin": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
-      "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/remapping": "^2.3.5",
-        "picomatch": "^4.0.3",
-        "webpack-virtual-modules": "^0.6.2"
-      },
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/vue-tsc": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@connectrpc/connect-web": "^2.1.1",
     "@tailwindcss/postcss": "^4.2.4",
     "@vitejs/plugin-basic-ssl": "^2.3.0",
-    "picocrank": "^1.14.1",
+    "picocrank": "^1.15.0",
     "pinia": "^3.0.4",
     "vite-plugin-mkcert": "^2.0.0",
     "vue": "^3.5.33",

--- a/frontend/src/components/CalendarComponent.vue
+++ b/frontend/src/components/CalendarComponent.vue
@@ -1,7 +1,10 @@
 <script setup lang="ts">
 import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
-import Calendar, { type CalendarEvent } from 'picocrank/vue/components/Calendar.vue'
+import Calendar, {
+  type CalendarEvent,
+  type CalendarEventMoveRequest
+} from 'picocrank/vue/components/Calendar.vue'
 import Section from 'picocrank/vue/components/Section.vue'
 import { createApiClient } from '../stores/api'
 
@@ -46,10 +49,17 @@ const dayMenu = ref<{ visible: boolean; x: number; y: number; date: Date | null 
   date: null
 })
 
-// Quick add state
-const quickAdd = ref<{ visible: boolean; date: Date | null; name: string; icon: string }>({
+// Quick add state (`endDate` set when creating from a multi-day range selection)
+const quickAdd = ref<{
+  visible: boolean
+  date: Date | null
+  endDate: Date | null
+  name: string
+  icon: string
+}>({
   visible: false,
   date: null,
+  endDate: null,
   name: '',
   icon: ''
 })
@@ -66,6 +76,16 @@ const tableTitle = ref<string>('')
 // Check if table has icon field
 const hasIconField = computed(() => {
   return tableStructure.value?.fields?.some((f: any) => f.name === 'icon')
+})
+
+/** Picocrank calendar drag is global; only enable when the table can persist date changes. */
+const calendarEventDragEnabled = computed(() => {
+  const fields = tableStructure.value?.fields ?? []
+  return fields.some(
+    (f: { name: string; type: string }) =>
+      (f.name === 'calendar_date' && f.type === 'date') ||
+      (f.name === 'starts' && f.type === 'datetime')
+  )
 })
 
 // Computed property for the section title
@@ -118,6 +138,45 @@ function parseServerDateTime(dateStr: any): Date | null {
   )
 
   return isNaN(date.getTime()) ? null : date
+}
+
+function startOfDayLocal(d: Date): Date {
+  const x = new Date(d.getTime())
+  x.setHours(0, 0, 0, 0)
+  return x
+}
+
+function endOfDayLocal(d: Date): Date {
+  const x = new Date(d.getTime())
+  x.setHours(23, 59, 59, 0)
+  return x
+}
+
+function shiftDateByCalendarDays(d: Date, deltaDays: number): Date {
+  const out = new Date(d.getTime())
+  out.setDate(out.getDate() + deltaDays)
+  return out
+}
+
+function toMysqlDate(d: Date): string {
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function toMysqlDateTime(d: Date): string {
+  const year = d.getFullYear()
+  const month = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  const hours = String(d.getHours()).padStart(2, '0')
+  const minutes = String(d.getMinutes()).padStart(2, '0')
+  const seconds = String(d.getSeconds()).padStart(2, '0')
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+}
+
+function itemHasMovableDateData(item: Item): boolean {
+  return Boolean(getItemValue(item, 'calendar_date') || getItemValue(item, 'starts'))
 }
 
 // Convert SickRock items to CalendarEvents
@@ -325,6 +384,115 @@ function handleDateClick(date: Date) {
   }
 }
 
+/** Picocrank: drag across days then release; same-day selection also emits `date-click`. */
+function handleDateRangeSelect(start: Date, end: Date) {
+  const lo = startOfDayLocal(start)
+  const hi = startOfDayLocal(end)
+  if (lo.getTime() === hi.getTime()) {
+    return
+  }
+  quickAdd.value = {
+    visible: true,
+    date: new Date(lo),
+    endDate: new Date(hi),
+    name: '',
+    icon: ''
+  }
+  setTimeout(() => {
+    const input = document.querySelector('.quick-add-input') as HTMLInputElement
+    if (input) {
+      input.focus()
+    }
+  }, 100)
+}
+
+async function handleEventMoveRequest(payload: CalendarEventMoveRequest) {
+  const { event, sourceDate, targetDate, respond } = payload
+  const item = (event as { _originalItem?: Item })._originalItem
+  if (!item) {
+    respond(false)
+    return
+  }
+  if (!itemHasMovableDateData(item)) {
+    error.value =
+      'This event is shown from created time only; add `calendar_date` or `starts` to move it.'
+    respond(false)
+    return
+  }
+
+  try {
+    const structureRes =
+      tableStructure.value ?? (await client.getTableStructure({ pageId: props.tableId }))
+    if (!tableStructure.value) {
+      tableStructure.value = structureRes
+    }
+
+    const fields = structureRes.fields ?? []
+    const hasCalendarDateField = fields.some(
+      (f: { name: string; type: string }) => f.name === 'calendar_date' && f.type === 'date'
+    )
+    const hasStartsField = fields.some(
+      (f: { name: string; type: string }) => f.name === 'starts' && f.type === 'datetime'
+    )
+    const hasFinishesField = fields.some(
+      (f: { name: string; type: string }) => f.name === 'finishes' && f.type === 'datetime'
+    )
+
+    const deltaDays = Math.round(
+      (startOfDayLocal(targetDate).getTime() - startOfDayLocal(sourceDate).getTime()) /
+        (24 * 60 * 60 * 1000)
+    )
+    if (deltaDays === 0) {
+      respond(true)
+      return
+    }
+
+    const additionalFields: Record<string, string> = {}
+    const itemId = String(getItemValue(item, 'id'))
+    const calVal = getItemValue(item, 'calendar_date')
+    const startsVal = getItemValue(item, 'starts')
+    const finishesVal = getItemValue(item, 'finishes')
+
+    if (hasCalendarDateField && calVal) {
+      const parsed = parseServerDateTime(calVal)
+      if (!parsed) {
+        respond(false)
+        return
+      }
+      additionalFields.calendar_date = toMysqlDate(shiftDateByCalendarDays(parsed, deltaDays))
+    } else if (hasStartsField && startsVal) {
+      const startParsed = parseServerDateTime(startsVal)
+      if (!startParsed) {
+        respond(false)
+        return
+      }
+      additionalFields.starts = toMysqlDateTime(shiftDateByCalendarDays(startParsed, deltaDays))
+      if (hasFinishesField && finishesVal) {
+        const endParsed = parseServerDateTime(finishesVal)
+        if (endParsed) {
+          additionalFields.finishes = toMysqlDateTime(shiftDateByCalendarDays(endParsed, deltaDays))
+        }
+      }
+    } else {
+      error.value = 'This table has no date columns that can be updated for this item.'
+      respond(false)
+      return
+    }
+
+    await client.editItem({
+      pageId: props.tableId,
+      id: itemId,
+      additionalFields
+    })
+    await reloadItems()
+    respond(true)
+  } catch (e) {
+    console.error('Failed to move calendar event:', e)
+    error.value = `Failed to move item: ${e}`
+    respond(false)
+  }
+}
+
 function handleMonthChange(month: number, year: number) {
   currentMonth.value = month
   currentYear.value = year
@@ -345,6 +513,7 @@ function showQuickAdd(date: Date) {
   quickAdd.value = {
     visible: true,
     date: date,
+    endDate: null,
     name: '',
     icon: ''
   }
@@ -361,9 +530,63 @@ function hideQuickAdd() {
   quickAdd.value = {
     visible: false,
     date: null,
+    endDate: null,
     name: '',
     icon: ''
   }
+}
+
+/**
+ * Sets `calendar_date` and/or `starts`/`finishes` on `additionalFields` from quick-add state.
+ * @returns false if validation failed (`error` set)
+ */
+function appendQuickAddDateFields(
+  additionalFields: Record<string, string>,
+  structureRes: { fields?: Array<{ name: string; type: string }> }
+): boolean {
+  const fields = structureRes.fields ?? []
+  const hasCalendarDateField = fields.some(
+    (f: { name: string; type: string }) => f.name === 'calendar_date' && f.type === 'date'
+  )
+  const hasStartsField = fields.some(
+    (f: { name: string; type: string }) => f.name === 'starts' && f.type === 'datetime'
+  )
+  const hasFinishesField = fields.some(
+    (f: { name: string; type: string }) => f.name === 'finishes' && f.type === 'datetime'
+  )
+
+  const d0 = quickAdd.value.date
+  if (!d0) return false
+
+  const rangeEnd = quickAdd.value.endDate
+  const isRange = rangeEnd !== null
+
+  if (isRange) {
+    if (!hasStartsField || !hasFinishesField) {
+      error.value =
+        'Multi-day quick add requires `starts` and `finishes` datetime columns on this table.'
+      return false
+    }
+    additionalFields.starts = toMysqlDateTime(startOfDayLocal(d0))
+    additionalFields.finishes = toMysqlDateTime(endOfDayLocal(rangeEnd))
+    return true
+  }
+
+  if (hasCalendarDateField) {
+    additionalFields.calendar_date = toMysqlDate(d0)
+    return true
+  }
+  if (hasStartsField) {
+    const year = d0.getFullYear()
+    const month = String(d0.getMonth() + 1).padStart(2, '0')
+    const day = String(d0.getDate()).padStart(2, '0')
+    const hours = String(d0.getHours()).padStart(2, '0')
+    const minutes = String(d0.getMinutes()).padStart(2, '0')
+    const seconds = String(d0.getSeconds()).padStart(2, '0')
+    additionalFields.starts = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
+    return true
+  }
+  return true
 }
 
 async function saveItem() {
@@ -381,29 +604,9 @@ async function saveItem() {
       additionalFields.icon = quickAdd.value.icon.trim()
     }
 
-    // Add calendar_date field if it exists in the table structure
     const structureRes = await client.getTableStructure({ pageId: props.tableId })
-    const hasCalendarDateField = structureRes.fields?.some(f => f.name === 'calendar_date' && f.type === 'date')
-
-    if (hasCalendarDateField) {
-      // Convert to MySQL date format (YYYY-MM-DD)
-      const year = quickAdd.value.date.getFullYear()
-      const month = String(quickAdd.value.date.getMonth() + 1).padStart(2, '0')
-      const day = String(quickAdd.value.date.getDate()).padStart(2, '0')
-      additionalFields.calendar_date = `${year}-${month}-${day}`
-    } else {
-      // Fallback to starts field if calendar_date doesn't exist
-      const hasStartsField = structureRes.fields?.some(f => f.name === 'starts' && f.type === 'datetime')
-      if (hasStartsField) {
-        // Convert to MySQL datetime format
-        const year = quickAdd.value.date.getFullYear()
-        const month = String(quickAdd.value.date.getMonth() + 1).padStart(2, '0')
-        const day = String(quickAdd.value.date.getDate()).padStart(2, '0')
-        const hours = String(quickAdd.value.date.getHours()).padStart(2, '0')
-        const minutes = String(quickAdd.value.date.getMinutes()).padStart(2, '0')
-        const seconds = String(quickAdd.value.date.getSeconds()).padStart(2, '0')
-        additionalFields.starts = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
-      }
+    if (!appendQuickAddDateFields(additionalFields, structureRes)) {
+      return
     }
 
     await client.createItem({
@@ -439,29 +642,9 @@ async function saveAndEdit() {
       additionalFields.icon = quickAdd.value.icon.trim()
     }
 
-    // Add calendar_date field if it exists in the table structure
     const structureRes = await client.getTableStructure({ pageId: props.tableId })
-    const hasCalendarDateField = structureRes.fields?.some(f => f.name === 'calendar_date' && f.type === 'date')
-
-    if (hasCalendarDateField) {
-      // Convert to MySQL date format (YYYY-MM-DD)
-      const year = quickAdd.value.date.getFullYear()
-      const month = String(quickAdd.value.date.getMonth() + 1).padStart(2, '0')
-      const day = String(quickAdd.value.date.getDate()).padStart(2, '0')
-      additionalFields.calendar_date = `${year}-${month}-${day}`
-    } else {
-      // Fallback to starts field if calendar_date doesn't exist
-      const hasStartsField = structureRes.fields?.some(f => f.name === 'starts' && f.type === 'datetime')
-      if (hasStartsField) {
-        // Convert to MySQL datetime format
-        const year = quickAdd.value.date.getFullYear()
-        const month = String(quickAdd.value.date.getMonth() + 1).padStart(2, '0')
-        const day = String(quickAdd.value.date.getDate()).padStart(2, '0')
-        const hours = String(quickAdd.value.date.getHours()).padStart(2, '0')
-        const minutes = String(quickAdd.value.date.getMinutes()).padStart(2, '0')
-        const seconds = String(quickAdd.value.date.getSeconds()).padStart(2, '0')
-        additionalFields.starts = `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`
-      }
+    if (!appendQuickAddDateFields(additionalFields, structureRes)) {
+      return
     }
 
     const res = await client.createItem({
@@ -621,12 +804,15 @@ onMounted(load)
         :current-month="currentMonth"
         :show-navigation="false"
         :current-year="currentYear"
+        :event-drag-enabled="calendarEventDragEnabled"
         :get-event-date-range="getEventDateRange"
         :format-event-time="formatEventTime"
         @event-click="handleEventClick"
         @date-click="handleDateClick"
+        @date-range-select="handleDateRangeSelect"
         @month-change="handleMonthChange"
         @event-context-menu="handleEventContextMenu"
+        @event-move-request="handleEventMoveRequest"
       >
         <template #event="{ event, date, position }">
           <div class="event-content" :title="getEventTooltip(event)">
@@ -716,7 +902,12 @@ onMounted(load)
       <div class="quick-add-content">
         <h3>Quick Add Item</h3>
         <p class="quick-add-date">
-          {{ quickAdd.date?.toLocaleDateString() }}
+          <template v-if="quickAdd.endDate && quickAdd.date">
+            {{ quickAdd.date.toLocaleDateString() }} – {{ quickAdd.endDate.toLocaleDateString() }}
+          </template>
+          <template v-else>
+            {{ quickAdd.date?.toLocaleDateString() }}
+          </template>
         </p>
         <div class="quick-add-form">
           <input


### PR DESCRIPTION
# PR Introduction

This PR upgrades **picocrank** to **^1.15.0** and integrates the calendar’s **date range selection** and **event drag-and-drop** into SickRock’s calendar view (`CalendarComponent.vue`). It is opened from a **feature branch on the same repository** (not a personal fork).

- **Date range**: multi-day drag on empty cells opens Quick Add with a visible range; save writes **`starts`** (start of first day) and **`finishes`** (end of last day) when both datetime columns exist on the table. Single-day selection continues to use **`date-click`** (day menu) as before.
- **Drag / drop**: **`event-move-request`** updates the row via **`editItem`** with shifted **`calendar_date`** (when that column drives the event) or **`starts`/`finishes`**, and calls **`respond(true)`** only after a successful API update. Dragging is enabled only when the table schema includes movable date columns.

# Checklist

Please put a X in the boxes as evidence of reading through the checklist.

- [ ] I have forked the project, and raised this PR on a feature branch. *(same-repo feature branch `cursor/bceaa8e9`)* 
- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guide and understand the 3-line change suggestion.
- [ ] The default `make` lint tasks run without any issues.
- [X] I understand and accept the [AGPL-3.0 license](LICENSE) and [code of conduct](CODE_OF_CONDUCT.md), and my contributions fall under these.

**Note:** `make lint` was not run in this environment. CI runs `make -w frontend` (Vite production build); `npm run build` (`vue-tsc -b`) still reports existing strict-check issues across the app and in picocrank’s bundled `Calendar.vue` typings.
